### PR TITLE
No copy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ ego-tree = "0.10.0"
 winnow = "0.6.20"
 
 [lints.clippy]
-pedantic = "warn"
+pedantic = { level = "warn", priority = -1 }
+doc_markdown = "allow"

--- a/README.md
+++ b/README.md
@@ -22,22 +22,25 @@ This crate helps you parse the value of the `fields` query parameter into a tree
 ```rust
 use z157::Params;
 
-let params: Params = "(name,bio(height(meters,centimeters),age))".parse().unwrap();
+fn main() {
+    let params: Params = "(name,bio(height(meters,centimeters),age))"
+        .to_string().try_into().unwrap();
 
-assert!(!params.negation());
-let height = params.index(&["bio", "height"]).unwrap();
-assert!(height.children().any(|param| param.field_name() == "meters"));
-assert!(height.children().any(|param| param.field_name() == "centimeters"));
+    assert!(!params.negation());
+    let height = params.index(&["bio", "height"]).unwrap();
+    assert!(height.children().any(|param| param.field_name() == "meters"));
+    assert!(height.children().any(|param| param.field_name() == "centimeters"));
 
-for param in params.walk() {
-    // z157::Param::path returns a vector of ancestors from the top-level field name until
-    // and including itself.
-    println!("{:?}", param.path());
+    for param in params.walk() {
+        // z157::Param::path returns a vector of ancestors from the top-level
+        // field name until and including itself.
+        println!("{:?}", param.path());
+    }
+
+    let params: Params = "-(bio)".to_string().try_into().unwrap();
+
+    assert!(params.negation());
 }
-
-let params: Params = "-(bio)".parse().unwrap();
-
-assert!(params.negation());
 ```
 
 ## The field filter specification

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,2 @@
+[workspace]
+release_always = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 //! <negation>          ::= "!"
 //! ```
 
+mod maybe_slice;
 mod params;
 mod parser;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,8 @@
 //! ```
 //! use z157::Params;
 //!
-//! let params: Params = "(name,bio(height(meters,centimeters),age))".parse().unwrap();
+//! let params: Params = "(name,bio(height(meters,centimeters),age))"
+//!     .to_string().try_into().unwrap();
 //!
 //! assert!(!params.negation());
 //! let height = params.index(&["bio", "height"]).unwrap();
@@ -13,12 +14,12 @@
 //! assert!(height.children().any(|param| param.field_name() == "centimeters"));
 //!
 //! for param in params.walk() {
-//!     // z157::Param::path returns a vector of ancestors from the top-level field name until
-//!     // and including itself.
+//!     // z157::Param::path returns a vector of ancestors from the top-level
+//!     // field name until and including itself.
 //!     println!("{:?}", param.path());
 //! }
 //!
-//! let params: Params = "-(bio)".parse().unwrap();
+//! let params: Params = "-(bio)".to_string().try_into().unwrap();
 //!
 //! assert!(params.negation());
 //! ```
@@ -57,7 +58,7 @@ mod tests {
 
     #[test]
     fn can_index() {
-        let params: Params = "(a(b,c(d)),e)".parse().unwrap();
+        let params: Params = "(a(b,c(d)),e)".to_string().try_into().unwrap();
         assert!(!params.negation());
         params.index(&["a", "b"]).unwrap();
         params.index(&["a", "c"]).unwrap();

--- a/src/maybe_slice.rs
+++ b/src/maybe_slice.rs
@@ -1,0 +1,116 @@
+//! This module contains the [`MaybeSlice`] pointer type which is useful for
+//! self-referencing containers.
+//!
+//! The use case for a [`MaybeSlice`] is for keeping pointers to a buffer along
+//! with the buffer, without actually having a self-referential struct.
+//!
+//! Instead of a type like
+//!
+//! ```
+//! struct SelfReferential<'a> {
+//!     buffer: String,
+//!     references_buffer: &'a str,
+//! }
+//! ```
+//!
+//! which most of the time won't work due to challenges with pinning etc., we
+//! can have
+//!
+//! ```ignore
+//! struct KindOfSelfReferential {
+//!     buffer: String,
+//!     references_buffer: MaybeSlice,
+//! }
+//! ```
+//!
+//! and index the `buffer` using the `MaybeSlice`.
+
+use std::ops::Index;
+
+/// A reference to a [`str`] based on offsets.
+///
+/// A [`MaybeSlice`] can be used to index a [`str`], but it will panic if the
+/// contained offsets surpasses the bounds of the `str`.
+///
+/// The `MaybeSlice` can only be constructed by [`MaybeSlice::new`], which fails
+/// if the inner subslice does not point to within the outer slice.
+#[derive(Copy, Clone, Debug)]
+pub struct MaybeSlice {
+    start: usize,
+    end: usize,
+}
+
+impl MaybeSlice {
+    /// Create a [`MaybeSlice`] from two [`str`]s.
+    ///
+    /// The `inner` `str` must be entirely within the `outer` `str`, otherwise
+    /// this function will return `None`.
+    ///
+    /// The ways to create an inner slice from a `str` is usually by pointer
+    /// chasing within parser code (`winnow` etc.), but can also be done with
+    /// range indexing, e.g., `&"Hello, world!"[1..3]`.
+    ///
+    /// Using an inner `str` that matches a substring of `outer`, but does not
+    /// actually point to within `outer` will also fail.
+    pub fn new(outer: &str, inner: &str) -> Option<Self> {
+        let outer_begin = outer.as_ptr() as usize;
+        let outer_end = outer_begin + outer.len();
+        let inner_begin = inner.as_ptr() as usize;
+        let inner_end = inner_begin + inner.len();
+
+        if inner_begin < outer_begin || inner_end > outer_end {
+            return None;
+        }
+
+        let start = inner_begin - outer_begin;
+        Some(Self {
+            start,
+            end: start + inner.len(),
+        })
+    }
+
+    /// Check if the `MaybeSlice` is empty.
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+
+    /// Get the length of the `MaybeSlice`.
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+impl Index<MaybeSlice> for str {
+    type Output = str;
+
+    fn index(&self, index: MaybeSlice) -> &Self::Output {
+        &self[index.start..index.end]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new() {
+        let outer = "The quick brown fox jumps over the lazy dog";
+        let ms = MaybeSlice::new(outer, &outer[0..3]).unwrap();
+        assert_eq!(ms.start, 0);
+        assert_eq!(ms.end, 3);
+        let ms = MaybeSlice::new(outer, &outer[4..12]).unwrap();
+        assert_eq!(ms.start, 4);
+        assert_eq!(ms.end, 12);
+
+        let other = "brown";
+        assert!(MaybeSlice::new(outer, other).is_none());
+    }
+
+    #[test]
+    fn index() {
+        let outer = "The quick brown fox jumps over the lazy dog";
+        let ms = MaybeSlice::new(outer, &outer[0..3]).unwrap();
+        let the = &outer[ms];
+        assert_eq!("The", the);
+    }
+}


### PR DESCRIPTION
Allow parsing of fields without reallocating a string per field name.

Instead, we keep a single buffer and keep offsets to each field name.